### PR TITLE
Refine duplicate visualization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # coursera-test
-as the name says :-)
+
+As the name says :-)
+
+## Visualizing duplicate images
+
+This repository includes a small utility, `show_duplicates.py`, which scans a
+directory for duplicate images using the
+[imagededup](https://github.com/idealo/imagededup) library and displays the
+results.
+
+### Installation
+
+The utility depends on the optional extras for `imagededup` to handle image
+decoding. Install them with:
+
+```bash
+pip install "imagededup[full]"
+```
+
+### Usage
+
+Provide the path to the directory containing images:
+
+```bash
+python show_duplicates.py --dir /path/to/images
+```

--- a/show_duplicates.py
+++ b/show_duplicates.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Display duplicate images identified by imagededup.
+
+This script scans a directory for duplicate images using imagededup's
+perceptual hashing (PHash) method and then visualizes each set of duplicates.
+
+Example
+-------
+    python show_duplicates.py --dir /path/to/images
+"""
+
+import argparse
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Find and display duplicate images in a directory."
+    )
+    parser.add_argument(
+        "--dir",
+        type=Path,
+        required=True,
+        help="Path to the directory containing images to scan for duplicates.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Execute the CLI to find and display duplicate images."""
+    args = parse_args()
+
+    if not args.dir.is_dir():
+        raise SystemExit(f"Directory not found: {args.dir}")
+
+    try:
+        from imagededup.methods import PHash
+        from imagededup.utils import plot_duplicates
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional pkg
+        raise SystemExit(
+            "imagededup is required for this script. Install with 'pip install "
+            "imagededup[full]'"
+        ) from exc
+
+    hasher = PHash()
+    duplicates = hasher.find_duplicates(image_dir=str(args.dir))
+
+    visited: set[str] = set()
+    found_any = False
+    for filename, dup_files in duplicates.items():
+        if filename in visited:
+            continue
+        if dup_files:
+            found_any = True
+            plot_duplicates(
+                image_dir=str(args.dir), duplicate_map=duplicates, filename=filename
+            )
+            visited.update(dup_files)
+            visited.add(filename)
+
+    if not found_any:
+        print("No duplicates found.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- handle missing `imagededup` gracefully and skip repeated plots in `show_duplicates.py`
- document installation and usage in README

## Testing
- `pip install imagededup[full]` *(failed: Could not find a version that satisfies the requirement imagededup[full])* 
- `python show_duplicates.py -h`
- `python show_duplicates.py --dir .` *(failed: imagededup is required for this script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8e88480408332b78f239753db2c28