### PR TITLE
Add spinning doughnut demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # coursera-test
 as the name says :-)
+
+## Spinning doughnut
+
+Run the `spinning_doughnut.py` script to display a classic ASCII art doughnut
+that rotates in your terminal:
+
+```bash
+python spinning_doughnut.py
+```

--- a/spinning_doughnut.py
+++ b/spinning_doughnut.py
@@ -1,0 +1,50 @@
+"""Display a spinning ASCII doughnut in the terminal."""
+
+import math
+import sys
+import time
+
+# Rotation angles for the animation
+A = 0.0
+B = 0.0
+
+while True:
+    z = [0] * 1760  # z-buffer
+    b = [" "] * 1760  # output buffer
+
+    for j in range(0, 628, 7):
+        for i in range(0, 628, 2):
+            # Convert loop indices to radians
+            j_r = j / 100
+            i_r = i / 100
+
+            c = math.sin(i_r)
+            d = math.cos(j_r)
+            e = math.sin(A)
+            f = math.sin(j_r)
+            g = math.cos(A)
+            h = d + 2
+            D = 1 / (c * h * e + f * g + 5)
+            l = math.cos(i_r)
+            m = math.cos(B)
+            n = math.sin(B)
+            t = c * h * g - f * e
+
+            x = int(40 + 30 * D * (l * h * m - t * n))
+            y = int(12 + 15 * D * (l * h * n + t * m))
+            o = x + 80 * y
+            N = int(8 * ((f * e - c * d * g) * m - c * d * e - f * g - l * d * n))
+            if 0 <= y < 22 and 0 <= x < 80 and D > z[o]:
+                z[o] = D
+                b[o] = ".,-~:;=!*#$@"[max(N, 0)]
+
+    # Move cursor to top-left and render the frame with newlines
+    sys.stdout.write("\x1b[H")
+    for k in range(1760):
+        sys.stdout.write(b[k] if k % 80 else "\n")
+    sys.stdout.flush()
+
+    A += 0.04
+    B += 0.02
+    time.sleep(0.03)
+


### PR DESCRIPTION
## Summary
- add a Python script that renders a spinning ASCII doughnut in the terminal
- document how to run the spinning doughnut demo
- fix rendering logic so the animation looks like a real torus

## Testing
- `python -m py_compile spinning_doughnut.py`
- `python spinning_doughnut.py >/tmp/output.log & sleep 1; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68a8f3963bd08332bb16e5ce9fa96bf8